### PR TITLE
Add URL paste autolink feature

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,3 +145,26 @@ Before designing solutions, enumerate the complete problem space:
 3. **Identify the coupling.** Features that seem separate often share a communication channel (clipboard, file format, API). Design them together, not as afterthoughts to each other.
 
 Only after this enumeration should you design the implementation.
+
+## Plan Documents
+
+When creating implementation plans, save them to `docs/plans/` with a ULID filename:
+
+```
+docs/plans/01KHRS817S0EERAW6NG7FZT1K6.md
+```
+
+ULIDs are time-sortable unique identifiers. Generate one with:
+
+```bash
+node -e "
+const t = Date.now();
+const chars = '0123456789ABCDEFGHJKMNPQRSTVWXYZ';
+let ulid = '';
+for (let i = 0; i < 10; i++) { ulid = chars[t >> (i * 5) & 31] + ulid; }
+for (let i = 0; i < 16; i++) { ulid += chars[Math.floor(Math.random() * 32)]; }
+console.log(ulid);
+"
+```
+
+Plans should document the design decisions and rationale, not just the implementation steps. They serve as a record of why things were built a certain way.

--- a/docs/plans/01KHRS817S0EERAW6NG7FZT1K6.md
+++ b/docs/plans/01KHRS817S0EERAW6NG7FZT1K6.md
@@ -1,0 +1,136 @@
+# URL Paste Autolink Refactoring Plan
+
+## Goal
+Refactor the URL paste autolink code to be cleaner and handle the case where pasted content is an autolink (link where href = text) from another application.
+
+## Unified Flow
+
+1. **Detect if slice is a URL paste:**
+   - Plain text that is a valid HTTP URL, OR
+   - Has link mark where `href === text` (autolink from another app)
+   - If neither → return false, let PM handle normally
+
+2. **Extract `href`** from whichever case matched
+
+3. **Determine link text content:**
+   - Default: `linkText = href`
+   - If selection is non-empty AND inline (doesn't cross block boundaries):
+     `linkText = selected content (preserving marks like bold/italic)`
+
+4. **Construct the link slice:**
+   - Create slice containing `linkText` with link mark pointing to `href`
+
+5. **Paste using `tr.replaceSelection(slice)`:**
+   - PM handles all structural fixup (empty selection inserts, non-empty replaces, multi-block merges)
+
+6. **Cleanup:** Remove stored link mark so next typed char isn't linked
+
+## Helper Functions Needed
+
+### `isInlineSelection(state): boolean`
+Check if current selection is non-empty and doesn't cross block boundaries.
+
+```typescript
+function isInlineSelection(state: EditorState): boolean {
+  const { from, to, $from, $to } = state.selection;
+  if (from === to) return false; // empty selection
+  // Same parent block = inline selection
+  return $from.sameParent($to);
+}
+```
+
+### `addLinkMarkToFragment(fragment, mark, schema): Fragment`
+Recursively add a link mark to all text nodes in a fragment.
+
+```typescript
+function addLinkMarkToFragment(fragment: Fragment, mark: Mark): Fragment {
+  const nodes: Node[] = [];
+  fragment.forEach((node) => {
+    if (node.isText) {
+      nodes.push(node.mark(mark.addToSet(node.marks)));
+    } else if (node.content.size > 0) {
+      nodes.push(node.copy(addLinkMarkToFragment(node.content, mark)));
+    } else {
+      nodes.push(node);
+    }
+  });
+  return Fragment.from(nodes);
+}
+```
+
+## Refactored Paste Handler Logic
+
+```typescript
+// 1. Detect URL and extract href
+const sliceText = slice.content.textBetween(0, slice.content.size, "", "").trim();
+
+let href: string | null = null;
+
+// Check for plain text URL
+const plainUrl = parseHttpUrl(sliceText);
+if (plainUrl) {
+  href = plainUrl.href;
+} else {
+  // Check for autolink (link mark where href === text)
+  let linkHref: string | null = null;
+  slice.content.descendants((node) => {
+    const linkMark = node.marks?.find((m) => m.type === schema.marks.link);
+    if (linkMark) {
+      linkHref = linkMark.attrs.href;
+      return false;
+    }
+  });
+  if (linkHref && linkHref === sliceText) {
+    href = linkHref;
+  }
+}
+
+if (!href) {
+  // Not a URL paste, fall through
+  // ... rest of paste handler
+}
+
+// 2. Determine link text content
+const { state, dispatch } = view;
+const { selection } = state;
+const linkMark = schema.marks.link.create({ href });
+
+let linkSlice: Slice;
+
+if (selection.empty || !isInlineSelection(state)) {
+  // Empty or multi-block: link text = href
+  const linkNode = schema.text(href, [linkMark]);
+  linkSlice = new Slice(Fragment.from(linkNode), 0, 0);
+} else {
+  // Inline selection: link text = selected content with link mark added
+  const { from, to } = selection;
+  const selectedSlice = state.doc.slice(from, to);
+  const linkedContent = addLinkMarkToFragment(selectedSlice.content, linkMark);
+  linkSlice = new Slice(linkedContent, selectedSlice.openStart, selectedSlice.openEnd);
+}
+
+// 3. Paste
+const tr = state.tr.replaceSelection(linkSlice);
+tr.removeStoredMark(schema.marks.link);
+dispatch(tr);
+return true;
+```
+
+## What Gets Removed
+
+- The `hasLinkMark` check that skipped autolinks entirely
+- The separate Part 1 / Part 2 code paths
+- The "Case 2b" link extension logic (selecting inside existing link)
+
+## Behavior Changes
+
+| Scenario | Old Behavior | New Behavior |
+|----------|--------------|--------------|
+| Paste `<a href="http://x.com">http://x.com</a>` (autolink) with empty selection | Pasted as-is (link preserved) | Same - pasted as link |
+| Paste `<a href="http://x.com">http://x.com</a>` with inline selection "click" | Fell through to default paste (replaced "click" with the link) | "click" becomes link to x.com |
+| Paste `<a href="http://foo.com">http://bar.com</a>` (text≠href) | Fell through to default | Falls through (not an autolink) |
+| Paste plain URL with selection inside existing link | Extended to full link, replaced href | Just replaces selection (simpler) |
+
+## Questions
+
+1. Is dropping the "Case 2b" link extension logic okay? (It was for when selection is inside an existing link - it extended to cover the whole link before replacing href)

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -28,7 +28,7 @@ import { createImageNodeView } from "./imageNodeView";
 import { categorizeImageSrc, type ImageSrcType } from "./imageUtils";
 import { createMathDisplayNodeView } from "./mathNodeView";
 import { createMathPlugin } from "./mathPlugin";
-import { schema } from "./schema";
+import { parseHttpUrl, schema } from "./schema";
 import { normalizeTablesInSlice } from "./tableNormalize";
 
 // Re-export for backward compatibility
@@ -368,6 +368,101 @@ export function mountEditor(host: HTMLElement): EditorView {
 
           return true; // Consume the paste event
         }
+      }
+
+      // URL autolink: If the pasted content is just a URL (without existing links),
+      // make it a link. Skip if slice already has link marks - don't override them.
+      let hasLinkMark = false;
+      slice.content.descendants((node) => {
+        if (node.marks?.some((m) => m.type === schema.marks.link)) {
+          hasLinkMark = true;
+          return false; // stop iteration
+        }
+      });
+
+      const sliceText = slice.content
+        .textBetween(0, slice.content.size, "", "")
+        .trim();
+      const url = !hasLinkMark ? parseHttpUrl(sliceText) : null;
+
+      if (url) {
+        const href = url.href;
+        const { state, dispatch } = view;
+        const { selection } = state;
+
+        if (selection.empty) {
+          // Part 1: No selection - insert URL as linked text
+          const linkMark = schema.marks.link.create({ href });
+          const textNode = schema.text(sliceText, [linkMark]);
+          const tr = state.tr.replaceSelectionWith(textNode, false);
+          // Remove stored link mark so next typed char is unlinked
+          tr.removeStoredMark(schema.marks.link);
+          dispatch(tr);
+          return true;
+        }
+        // Part 2: Selection - apply link mark to selected text
+        // Case 2b: If selection is entirely inside one existing link,
+        // extend range to cover the full link (links are atomic to users)
+        let { from, to } = selection;
+
+        // Check if selection is entirely within one link
+        const $from = state.doc.resolve(from);
+        const $to = state.doc.resolve(to);
+        const linkAtFrom = $from
+          .marks()
+          .find((m) => m.type === schema.marks.link);
+        const linkAtTo = $to.marks().find((m) => m.type === schema.marks.link);
+
+        if (
+          linkAtFrom &&
+          linkAtTo &&
+          linkAtFrom.attrs.href === linkAtTo.attrs.href
+        ) {
+          // Selection is inside one link - find full extent
+          // Walk left from 'from' to find link start
+          let extendedFrom = from;
+          for (let pos = from - 1; pos >= 0; pos--) {
+            const $pos = state.doc.resolve(pos);
+            const linkAtPos = $pos
+              .marks()
+              .find((m) => m.type === schema.marks.link);
+            if (linkAtPos && linkAtPos.attrs.href === linkAtFrom.attrs.href) {
+              extendedFrom = pos;
+            } else {
+              break;
+            }
+          }
+          // Walk right from 'to' to find link end
+          let extendedTo = to;
+          const docSize = state.doc.content.size;
+          for (let pos = to; pos <= docSize; pos++) {
+            const $pos = state.doc.resolve(pos);
+            const linkAtPos = $pos
+              .marks()
+              .find((m) => m.type === schema.marks.link);
+            if (linkAtPos && linkAtPos.attrs.href === linkAtFrom.attrs.href) {
+              extendedTo = pos + 1;
+            } else {
+              break;
+            }
+          }
+          from = extendedFrom;
+          to = extendedTo;
+        }
+
+        const tr = state.tr;
+        // Remove any existing link marks in the range first
+        tr.removeMark(from, to, schema.marks.link);
+        // Add the new link mark
+        // DESIGN NOTE: tr.addMark across a multi-block range correctly applies
+        // the mark only to inline content within each block. Images (atom nodes)
+        // within the selection are unaffected - marks only apply to text nodes.
+        tr.addMark(from, to, schema.marks.link.create({ href }));
+        // Collapse selection to end and remove stored link mark
+        tr.setSelection(Selection.near(tr.doc.resolve(tr.mapping.map(to))));
+        tr.removeStoredMark(schema.marks.link);
+        dispatch(tr);
+        return true;
       }
 
       // Normalize tables in pasted content to enforce GFM semantics

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -386,7 +386,11 @@ export function mountEditor(host: HTMLElement): EditorView {
       // that auto-linked the URL). No other marks allowed, no content outside.
       let href: string | null = null;
       if (slice.content.childCount === 1) {
-        const node = slice.content.firstChild;
+        let node = slice.content.firstChild;
+        // Unwrap if single paragraph containing single child
+        if (node?.type.name === "paragraph" && node.content.childCount === 1) {
+          node = node.content.firstChild;
+        }
         if (node?.isText && node.text) {
           const url = parseHttpUrl(node.text);
           if (

--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -51,18 +51,13 @@ function isInlineSelection(state: EditorState): boolean {
 }
 
 /**
- * Recursively add a mark to all text nodes in a fragment.
+ * Add a mark to all nodes in a fragment of inline content.
+ * Works for both text nodes and inline atoms (like images).
  */
 function addMarkToFragment(fragment: Fragment, mark: Mark): Fragment {
   const nodes: Node[] = [];
   fragment.forEach((node) => {
-    if (node.isText) {
-      nodes.push(node.mark(mark.addToSet(node.marks)));
-    } else if (node.content.size > 0) {
-      nodes.push(node.copy(addMarkToFragment(node.content, mark)));
-    } else {
-      nodes.push(node);
-    }
+    nodes.push(node.mark(mark.addToSet(node.marks)));
   });
   return Fragment.from(nodes);
 }

--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -215,6 +215,16 @@ export const schema = new Schema({
         const attrs: Record<string, string> = { src, class: "pm-image" };
         if (alt) attrs.alt = alt;
         if (title) attrs.title = title;
+
+        // If image has a link mark, wrap in <a>
+        const linkMark = node.marks.find((m) => m.type.name === "link");
+        if (linkMark) {
+          return [
+            "a",
+            { href: linkMark.attrs.href, class: "pm-image-link" },
+            ["img", attrs],
+          ];
+        }
         return ["img", attrs];
       },
     },


### PR DESCRIPTION
## Summary

- Automatically create links when pasting URLs
- Handle autolinks from other apps (where href equals display text)
- Inline selection: selected text becomes link text, preserving marks (bold/italic)
- Empty or multi-block selection: URL becomes both link text and href

## Implementation

- Add `isSafeHref()` and `parseHttpUrl()` URL validation utilities
- Replace regex in link mark's `parseDOM` with `isSafeHref()`
- Add helper functions: `isInlineSelection()`, `addMarkToFragment()`
- Unified paste handler flow using `tr.replaceSelection()`

## Plan Document

Design rationale documented in `docs/plans/01KHRS817S0EERAW6NG7FZT1K6.md`

## Test plan

- [ ] Paste plain URL with empty selection → inserts linked URL
- [ ] Paste plain URL with inline selection → selection becomes link
- [ ] Paste plain URL with multi-block selection → replaces with linked URL
- [ ] Paste autolink (`<a href="url">url</a>`) → treated same as plain URL
- [ ] Paste link with different href and text → falls through to default paste
- [ ] Bold/italic text in selection is preserved when linked

🤖 Generated with [Claude Code](https://claude.com/claude-code)