### PR TITLE
Add link utilities and reorder marks

### DIFF
--- a/src/editor/editor.ts
+++ b/src/editor/editor.ts
@@ -26,6 +26,7 @@ import { isAllowedImageType } from "../storage/image";
 import { getImageManager } from "./ImageManager";
 import { createImageNodeView } from "./imageNodeView";
 import { categorizeImageSrc, type ImageSrcType } from "./imageUtils";
+import { unlinkCommand } from "./linkUtils";
 import { createMathDisplayNodeView } from "./mathNodeView";
 import { createMathPlugin } from "./mathPlugin";
 import { parseHttpUrl, schema } from "./schema";
@@ -149,6 +150,7 @@ const markKeymap = keymap({
   "Mod-i": toggleMark(schema.marks.em),
   "Mod-`": toggleMark(schema.marks.code),
   "Mod-Shift-`": toggleMark(schema.marks.strikethrough),
+  "Mod-Shift-k": unlinkCommand,
 });
 
 // Tab navigation from title to first block (skipping created timestamp)

--- a/src/editor/linkUtils.ts
+++ b/src/editor/linkUtils.ts
@@ -1,0 +1,53 @@
+import type { Mark, MarkType, ResolvedPos } from "prosemirror-model";
+
+/**
+ * Find the contiguous range of a mark containing the given position.
+ * Returns null if the position isn't inside a mark of the specified type.
+ */
+export function getMarkRange(
+  $pos: ResolvedPos,
+  markType: MarkType,
+): { from: number; to: number; mark: Mark } | null {
+  let start = $pos.parent.childAfter($pos.parentOffset);
+  if (!start.node) start = $pos.parent.childBefore($pos.parentOffset);
+  const node = start.node;
+  const mark = node?.marks.find((m) => m.type === markType);
+  if (!mark || !node) return null;
+
+  let startIndex = start.index,
+    startPos = $pos.start() + start.offset;
+  let endIndex = startIndex + 1,
+    endPos = startPos + node.nodeSize;
+
+  while (
+    startIndex > 0 &&
+    mark.isInSet($pos.parent.child(startIndex - 1).marks)
+  ) {
+    startPos -= $pos.parent.child(--startIndex).nodeSize;
+  }
+  while (
+    endIndex < $pos.parent.childCount &&
+    mark.isInSet($pos.parent.child(endIndex).marks)
+  ) {
+    endPos += $pos.parent.child(endIndex++).nodeSize;
+  }
+  return { from: startPos, to: endPos, mark };
+}
+
+/**
+ * Find the contiguous range of a link mark containing the given position.
+ * Returns null if the position isn't inside a link.
+ */
+export function getLinkRange(
+  $pos: ResolvedPos,
+  linkType: MarkType,
+): { from: number; to: number; href: string } | null {
+  const range = getMarkRange($pos, linkType);
+  return (
+    range && {
+      from: range.from,
+      to: range.to,
+      href: range.mark.attrs.href as string,
+    }
+  );
+}

--- a/src/editor/linkUtils.ts
+++ b/src/editor/linkUtils.ts
@@ -4,7 +4,7 @@ import type {
   Node as PMNode,
   ResolvedPos,
 } from "prosemirror-model";
-import type { Command } from "prosemirror-state";
+import type { Command, Transaction } from "prosemirror-state";
 
 /**
  * Find the contiguous range of a mark containing the given position.
@@ -100,3 +100,19 @@ export const unlinkCommand: Command = (state, dispatch) => {
   dispatch?.(state.tr.removeMark(from, to, linkType));
   return true;
 };
+
+/**
+ * Set link href on a range, replacing any existing links.
+ * Returns the transaction for chaining.
+ */
+export function setLinkHref(
+  tr: Transaction,
+  from: number,
+  to: number,
+  href: string,
+  linkType: MarkType,
+): Transaction {
+  return tr
+    .removeMark(from, to, linkType)
+    .addMark(from, to, linkType.create({ href }));
+}

--- a/src/editor/linkUtils.ts
+++ b/src/editor/linkUtils.ts
@@ -4,6 +4,7 @@ import type {
   Node as PMNode,
   ResolvedPos,
 } from "prosemirror-model";
+import type { Command } from "prosemirror-state";
 
 /**
  * Find the contiguous range of a mark containing the given position.
@@ -81,3 +82,21 @@ export function linkSpansInRange(
 
   return spans;
 }
+
+/**
+ * Remove link marks from selection or the link at cursor.
+ */
+export const unlinkCommand: Command = (state, dispatch) => {
+  const { from, to, empty } = state.selection;
+  const linkType = state.schema.marks.link;
+
+  if (empty) {
+    const range = getLinkRange(state.doc.resolve(from), linkType);
+    if (!range) return false;
+    dispatch?.(state.tr.removeMark(range.from, range.to, linkType));
+    return true;
+  }
+  if (!state.doc.rangeHasMark(from, to, linkType)) return false;
+  dispatch?.(state.tr.removeMark(from, to, linkType));
+  return true;
+};

--- a/src/editor/schema.ts
+++ b/src/editor/schema.ts
@@ -229,10 +229,8 @@ export const schema = new Schema({
       },
     },
   },
+  // Mark order determines DOM nesting: first = outermost (lowest rank)
   marks: {
-    strong: marks.strong,
-    em: marks.em,
-    code: marks.code,
     link: {
       ...marks.link,
       parseDOM: [
@@ -262,5 +260,8 @@ export const schema = new Schema({
         return ["s", 0];
       },
     },
+    code: marks.code,
+    strong: marks.strong,
+    em: marks.em,
   },
 });


### PR DESCRIPTION
## Summary

- Add `src/editor/linkUtils.ts` with utilities for working with link marks:
  - `getMarkRange` / `getLinkRange` - find contiguous mark span at a position
  - `linkSpansInRange` - find all link spans overlapping a range
  - `unlinkCommand` - remove links from selection or cursor position
  - `setLinkHref` - apply/replace link href on a range
- Reorder marks in schema so links nest outermost in DOM (better for click handling and screen readers)
- Add Mod-Shift-K keybinding for unlink

## Test plan

- [x] Verify Cmd/Ctrl-Shift-K removes link when cursor is inside a link
- [x] Verify Cmd/Ctrl-Shift-K removes all links in a selection
- [x] Verify links render as outermost element (e.g., `<a><strong>text</strong></a>` not `<strong><a>text</a></strong>`)

🤖 Generated with [Claude Code](https://claude.ai/code)